### PR TITLE
fix: creators in deployable applications

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,6 +28,7 @@ sentry-sdk = {version = "*", extras = ["fastapi"]}
 sickle = "*"
 aiohttp = "*"
 email-validator = "*"
+typing-extensions = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "01ac9547b31fc18513c2e4d6fe906acd8b9c032e4ad9b53cc665aa949d5e6a74"
+            "sha256": "bc49ac794d353458668b61e74f6714c92d72acb1fd434a9f096f741c40a9f92c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1997,11 +1997,12 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
-                "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+                "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8",
+                "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==4.15.0"
+            "version": "==4.16.0"
         },
         "typing-inspection": {
             "hashes": [

--- a/app/transform/transformers/deployable_service.py
+++ b/app/transform/transformers/deployable_service.py
@@ -93,34 +93,55 @@ class DeployableServiceTransformer(BaseTransformer):
 
     @staticmethod
     def transform_creators(df: DataFrame) -> DataFrame:
-        """Transform creators field for Solr indexing"""
+        """
+        Transform creator metadata into fields used for Solr indexing.
 
-        # Option 1: Extract creator names using creatorName field
+        The current deployable service schema provides only the creator's
+        first name, last name and email address. These values are used to
+        create searchable creator-related fields for Solr.
+
+        The following fields are created:
+
+        - creator_names:
+            Creator full names built from first and last names.
+        - creator_identifiers:
+            Creator email addresses.
+        - creators_searchable:
+            Searchable text combining creator names and email addresses.
+        """
+
+        creators = "coalesce(creators, array())"
+
+        # Extract creator names.
         df = df.withColumn(
             "creator_names",
-            expr("transform(creators, x -> x.creatorNameTypeInfo.creatorName)"),
+            expr(f"""
+                transform({creators}, x ->
+                    nullif(trim(concat_ws(' ', x.firstName, x.lastName)), '')
+                )
+            """),
         )
 
-        # Option 2: Extract creator identifiers (GitHub URLs)
+        # Extract creator identifiers (currently email addresses).
         df = df.withColumn(
-            "creator_identifiers", expr("transform(creators, x -> x.nameIdentifier)")
+            "creator_identifiers",
+            expr(f"""
+                transform({creators}, x ->
+                    nullif(x.email, '')
+                )
+            """),
         )
 
-        # Option 3: Extract creator affiliations
-        df = df.withColumn(
-            "creator_affiliations",
-            expr("transform(creators, x -> x.creatorAffiliationInfo.affiliation)"),
-        )
-
-        # Option 4: Create a searchable text field combining all creator info
+        # Build searchable creator text.
         df = df.withColumn(
             "creators_searchable",
-            expr("""
-                transform(creators, x -> 
-                    concat(
-                        x.creatorNameTypeInfo.creatorName, ' ', 
-                        x.creatorAffiliationInfo.affiliation
-                    )
+            expr(f"""
+                transform({creators}, x ->
+                    trim(concat_ws(
+                        ' ',
+                        nullif(trim(concat_ws(' ', x.firstName, x.lastName)), ''),
+                        nullif(x.email, '')
+                    ))
                 )
             """),
         )

--- a/schemas/common/creator.py
+++ b/schemas/common/creator.py
@@ -1,57 +1,65 @@
-"""Creator model schema"""
+"""Creator model schema."""
 
-from pydantic import AnyHttpUrl, BaseModel
+from pydantic import AnyHttpUrl, BaseModel, EmailStr
 
 
 class CreatorNameTypeInfo(BaseModel):
     """
-    Information about the creator's name type.
+    Additional information describing the creator's preferred display name.
 
     Attributes:
-        nameType (str):
-            The type of the creator's name (e.g., "ir_name_type-organizational").
-        creatorName (str):
-            The full name of the creator.
+        nameType (str | None):
+            Type of the creator's name (e.g. "Organizational" or "Personal").
+            Optional because some data sources do not provide it.
+        creatorName (str | None):
+            Preferred full display name of the creator.
+            Optional because some data sources only provide first and last names.
     """
 
-    nameType: str
-    creatorName: str
+    nameType: str | None = None
+    creatorName: str | None = None
 
 
 class CreatorAffiliationInfo(BaseModel):
     """
-    Information about the creator's affiliation.
+    Additional information describing the creator's affiliation.
 
     Attributes:
-        affiliation (str):
-            The name of the organization the creator is affiliated with.
-        affiliationIdentifier (AnyHttpUrl):
-            The identifier URL for the affiliation (e.g., ROR ID).
+        affiliation (str | None):
+            Name of the creator's affiliated organisation.
+        affiliationIdentifier (AnyHttpUrl | None):
+            Persistent identifier of the affiliation (e.g. a ROR identifier).
     """
 
-    affiliation: str
-    affiliationIdentifier: AnyHttpUrl
+    affiliation: str | None = None
+    affiliationIdentifier: AnyHttpUrl | None = None
 
 
 class Creator(BaseModel):
     """
-    Model representing a creator/author of a deployable service.
+    Model representing a creator of a deployable service.
 
     Attributes:
-        givenName (str):
-            The given (first) name of the creator.
-        familyName (str):
-            The family (last) name of the creator.
-        nameIdentifier (AnyHttpUrl):
-            The identifier URL for the creator (e.g., GitHub profile, ORCID).
-        creatorNameTypeInfo (CreatorNameTypeInfo):
-            Information about the creator's name type.
-        creatorAffiliationInfo (CreatorAffiliationInfo):
-            Information about the creator's organizational affiliation.
+        firstName (str):
+            Creator's given (first) name.
+        lastName (str):
+            Creator's family (last) name.
+        email (EmailStr | None):
+            Public email address of the creator, when available.
+        role (str | None):
+            Creator's contribution role (e.g. CRediT taxonomy).
+        nameIdentifier (AnyHttpUrl | None):
+            Persistent identifier of the creator (e.g. ORCID or GitHub profile).
+        creatorNameTypeInfo (CreatorNameTypeInfo | None):
+            Optional metadata describing the creator's name. Currently empty.
+        creatorAffiliationInfo (CreatorAffiliationInfo | None):
+            Optional metadata describing the creator's organisational affiliation. Currently empty.
     """
 
-    givenName: str
-    familyName: str
-    nameIdentifier: AnyHttpUrl
-    creatorNameTypeInfo: CreatorNameTypeInfo
-    creatorAffiliationInfo: CreatorAffiliationInfo
+    firstName: str
+    lastName: str
+    email: EmailStr | None = None
+    role: str | None = None
+    nameIdentifier: AnyHttpUrl | None = None
+    creatorNameTypeInfo: CreatorNameTypeInfo | None = None
+    creatorAffiliationInfo: CreatorAffiliationInfo | None = None

--- a/schemas/db/deployable_service.py
+++ b/schemas/db/deployable_service.py
@@ -15,8 +15,6 @@ class DeployableServiceDBSchema(BaseModel):
             The abbreviation of the deployable service.
         catalogues (List[str]):
             A list of catalogues associated with the deployable service.
-        creator_affiliations (List[str]):
-            A list of creator affiliations extracted from the creators field.
         creator_identifiers (List[str]):
             A list of creator identifiers (URLs) extracted from the creators field.
         creator_names (List[str]):
@@ -71,7 +69,6 @@ class DeployableServiceDBSchema(BaseModel):
 
     abbreviation: str
     catalogues: List[str]
-    creator_affiliations: List[str]
     creator_identifiers: List[str]
     creator_names: List[str]
     creators_searchable: List[str]

--- a/schemas/old/output/deployable_service.py
+++ b/schemas/old/output/deployable_service.py
@@ -28,7 +28,6 @@ deployable_service_output_schema = {
     "upstream_id": "bigint",
     "creator_names": "array<string>",
     "creator_identifiers": "array<string>",
-    "creator_affiliations": "array<string>",
     "creators_searchable": "array<string>",
     "type": "string",
 }

--- a/schemas/se/deployable_service.py
+++ b/schemas/se/deployable_service.py
@@ -13,8 +13,6 @@ class DeployableServiceSESchema(BaseModel):
     Attributes:
         catalogues (List[str]):
             A list of catalogues associated with the deployable service. Used in filters.
-        creator_affiliations (List[str]):
-            A list of creator affiliations. Used in filters and faceting.
         creator_names (List[str]):
             A list of creator names. Used in searching and filtering.
         creators_searchable (List[str]):
@@ -54,7 +52,6 @@ class DeployableServiceSESchema(BaseModel):
     """
 
     catalogues: List[str]
-    creator_affiliations: List[str]
     creator_names: List[str]
     creators_searchable: List[str]
     description: str


### PR DESCRIPTION
Now creators look like:
```
    "creators": [
      {
        "email": "default@mail.com",
        "lastName": "lastname",
        "firstName": "name",
        "creatorNameTypeInfo": {},
        "creatorAffiliationInfo": {}
      }
    ],
```
Previously, they had those values more or less in `creatorNameTypeInfo` and `creatorAffiliationInfo`, now they are empty. 
