### PR TITLE
feat: [#98] add cron scheduler for sage pipeline

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -29,6 +29,7 @@ sickle = "*"
 aiohttp = "*"
 email-validator = "*"
 typing-extensions = "*"
+apscheduler = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bc49ac794d353458668b61e74f6714c92d72acb1fd434a9f096f741c40a9f92c"
+            "sha256": "f3eb86a0c9ef9077eb5240e6b50c11497392432808c9847350a100ef7c37ec16"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -198,6 +198,15 @@
             ],
             "markers": "python_version >= '3.10'",
             "version": "==4.13.0"
+        },
+        "apscheduler": {
+            "hashes": [
+                "sha256:bbeb2ec02d23d3c06a6c07ed7f0f3939ada6680eb121fae809a69bb42c537a30",
+                "sha256:cd2fcc9330039a81a5893472ad49facf23a6d5604cbe1d918c835c6de7834d5a"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==3.11.3"
         },
         "async-timeout": {
             "hashes": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,12 @@ services:
       - redis
       - worker
 
+  sage-cron:
+    build: ./
+    command: python -m sage.scheduler
+    volumes:
+      - ./sage/.env:/app/sage/.env:ro
+
   redis:
     image: redis:7
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,11 +40,15 @@ services:
       - redis
       - worker
 
-  sage-cron:
-    build: ./
-    command: python -m sage.scheduler
-    volumes:
-      - ./sage/.env:/app/sage/.env:ro
+# Uncomment the following section to enable the cron service for periodic data synchronization.
+# Make sure to configure the cron jobs in the `sage/scheduler.py` file.
+#  sage-cron:
+#    build: ./
+#    command: python -m sage.scheduler
+#    profiles:
+#      - sage-cron
+#    volumes:
+#      - ./sage/.env:/app/sage/.env:ro
 
   redis:
     image: redis:7

--- a/sage/README.md
+++ b/sage/README.md
@@ -54,6 +54,7 @@ AGGREGATOR_API_KEY=...
 SOLR_URL=...
 SOLR_COLS_NAME=...
 REQUEST_TIMEOUT=300
+SCHEDULER_INTERVAL_MINUTES=10
 ```
 
 ## Pipeline workflow
@@ -228,6 +229,14 @@ The pipeline is designed to avoid modifying Solr until the new data has been suc
 \* The pipeline stops when the delete operation reports a failure.
 
 If indexing fails after the delete operation has succeeded, the Solr collection may temporarily contain an incomplete snapshot. The checksum is not updated in this case, so the next pipeline execution will retry the synchronization.
+
+## Running on a schedule
+
+The pipeline can also be run continuously (every SCHEDULER_INTERVAL_MINUTES) using the scheduler entrypoint:
+
+```bash
+python -m sage.scheduler
+```
 
 ## Running tests
 

--- a/sage/README.md
+++ b/sage/README.md
@@ -22,6 +22,22 @@ or, if using Pipenv:
 pipenv run python -m sage.pipeline
 ```
 
+## Running on a schedule
+
+To run the pipeline continuously every 10 minutes (e.g. in a long-running container), use the scheduler entrypoint instead of invoking the pipeline directly:
+
+```bash
+python -m sage.scheduler
+```
+
+or, if using Pipenv:
+
+```bash
+pipenv run python -m sage.scheduler
+```
+
+This runs the pipeline once immediately, then every 10 minutes via a cron-style trigger (`*/10 * * * *`, UTC). A single failed run is logged and does not stop the scheduler.
+
 ## Configuration
 
 The pipeline reads its configuration from:

--- a/sage/README.md
+++ b/sage/README.md
@@ -22,9 +22,11 @@ or, if using Pipenv:
 pipenv run python -m sage.pipeline
 ```
 
+This executes a single pipeline run.
+
 ## Running on a schedule
 
-To run the pipeline continuously every 10 minutes (e.g. in a long-running container), use the scheduler entrypoint instead of invoking the pipeline directly:
+To run the pipeline continuously using the scheduler entrypoint:
 
 ```bash
 python -m sage.scheduler
@@ -36,7 +38,7 @@ or, if using Pipenv:
 pipenv run python -m sage.scheduler
 ```
 
-This runs the pipeline once immediately, then every 10 minutes via a cron-style trigger (`*/10 * * * *`, UTC). A single failed run is logged and does not stop the scheduler.
+The scheduler runs the pipeline periodically according to `SCHEDULER_INTERVAL_MINUTES` (10 minutes by default). It uses UTC and continues running if an individual pipeline execution fails. The first pipeline run occurs after the configured interval.
 
 ## Configuration
 
@@ -57,6 +59,18 @@ REQUEST_TIMEOUT=300
 SCHEDULER_INTERVAL_MINUTES=10
 ```
 
+### Configuration variables
+
+| Variable | Required | Default | Description |
+|---|---|---:|---|
+| `AGGREGATOR_URL` | Yes | - | SAGE Aggregator catalog query endpoint |
+| `AGGREGATOR_API_KEY` | Yes | - | API key used to access the Aggregator |
+| `AGGREGATOR_API_LIMIT` | No | `20` | Maximum number of catalog results requested from the Aggregator |
+| `SOLR_URL` | Yes | - | Solr server URL |
+| `SOLR_COLS_NAME` | Yes | - | Solr collection name |
+| `REQUEST_TIMEOUT` | No | `30` | HTTP request timeout in seconds |
+| `SCHEDULER_INTERVAL_MINUTES` | No | `10` | Interval between scheduled pipeline runs, in minutes |
+
 ## Pipeline workflow
 
 The pipeline synchronizes the SAGE Aggregator dataset snapshot with the Solr collection.
@@ -65,29 +79,31 @@ The pipeline synchronizes the SAGE Aggregator dataset snapshot with the Solr col
 flowchart TD
     A[Aggregator API] --> B[Fetch catalog snapshot]
     B --> C[Flatten datasets]
-    C --> D[Calculate SHA-256 checksum]
-    D --> E[Load previous checksum]
-    E --> F{Checksum changed?}
+    C --> D[Normalize snapshot for checksum]
+    D --> E[Remove dynamic odrl:hasPolicy.@id]
+    E --> F[Calculate SHA-256 checksum]
+    F --> G[Load previous checksum]
+    G --> H{Checksum changed?}
 
-    F -->|No| G[Stop - no changes]
-    F -->|Yes| H[Transform all datasets]
+    H -->|No| I[Stop - no changes]
+    H -->|Yes| J[Transform all datasets]
 
-    H --> I{Transformation successful?}
+    J --> K{Transformation successful?}
 
-    I -->|No| J[Stop - keep existing Solr data]
-    I -->|Yes| K[Delete all documents from Solr]
+    K -->|No| L[Stop - keep existing Solr data]
+    K -->|Yes| M[Delete all documents from Solr]
 
-    K --> L{Delete successful?}
+    M --> N{Delete successful?}
 
-    L -->|No| M[Stop - keep checksum unchanged]
-    L -->|Yes| N[Index transformed snapshot in batches]
+    N -->|No| O[Stop - keep checksum unchanged]
+    N -->|Yes| P[Index transformed snapshot in batches]
 
-    N --> O{Indexing successful?}
+    P --> Q{Indexing successful?}
 
-    O -->|No| P[Stop - keep checksum unchanged]
-    O -->|Yes| Q[Save new checksum]
+    Q -->|No| R[Stop - keep checksum unchanged]
+    Q -->|Yes| S[Save new checksum]
 
-    Q --> R[Pipeline finished successfully]
+    S --> T[Pipeline finished successfully]
 ```
 
 ### 1. Fetching data
@@ -104,20 +120,33 @@ Catalog-level metadata is also attached to each dataset:
 
 ### 2. Calculating the checksum
 
-After flattening the data, the pipeline calculates a SHA-256 checksum representing the complete dataset snapshot.
+After flattening the data, the pipeline calculates a SHA-256 checksum representing the dataset snapshot.
 
 Datasets are sorted by `@id` before calculating the checksum, so the order of datasets in the Aggregator response does not affect the result.
+
+Before calculating the checksum, the dynamically generated:
+
+```text
+odrl:hasPolicy.@id
+```
+
+value is removed from the checksum input.
+
+The Aggregator may generate a different policy ID for the same dataset between requests. Including this value in the checksum would therefore incorrectly indicate that the dataset had changed.
+
+The rest of the `odrl:hasPolicy` object remains part of the checksum, so actual changes to the policy content can still trigger a synchronization.
 
 The checksum changes when datasets are:
 
 - added
 - removed
 - modified
+- meaningfully changed in their policy content
 
 The previous checksum is stored in:
 
 ```text
-state/aggregator_checksum
+sage/state/aggregator_checksum
 ```
 
 ### 3. Skipping unchanged snapshots
@@ -142,7 +171,7 @@ transform_raw_dataset()
 
 Transformation happens **before modifying Solr**.
 
-This ensures that failures during fetching or transformation do not cause the existing Solr data to be deleted.
+This ensures that failures during transformation do not cause the existing Solr data to be deleted.
 
 If no datasets can be successfully transformed, the pipeline stops without modifying Solr.
 
@@ -229,14 +258,6 @@ The pipeline is designed to avoid modifying Solr until the new data has been suc
 \* The pipeline stops when the delete operation reports a failure.
 
 If indexing fails after the delete operation has succeeded, the Solr collection may temporarily contain an incomplete snapshot. The checksum is not updated in this case, so the next pipeline execution will retry the synchronization.
-
-## Running on a schedule
-
-The pipeline can also be run continuously (every SCHEDULER_INTERVAL_MINUTES) using the scheduler entrypoint:
-
-```bash
-python -m sage.scheduler
-```
 
 ## Running tests
 

--- a/sage/client.py
+++ b/sage/client.py
@@ -1,4 +1,5 @@
 """Aggregator client for fetching the catalog from PCSS"""
+
 from typing import Any, Dict
 
 import requests

--- a/sage/client.py
+++ b/sage/client.py
@@ -1,3 +1,4 @@
+"""Aggregator client for fetching the catalog from PCSS"""
 from typing import Any, Dict
 
 import requests

--- a/sage/logging_config.py
+++ b/sage/logging_config.py
@@ -1,0 +1,10 @@
+"""Logging configration for the Sage project."""
+
+import logging
+
+
+def configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )

--- a/sage/pipeline.py
+++ b/sage/pipeline.py
@@ -1,18 +1,14 @@
 import hashlib
 import json
-import logging
+from logging import getLogger
 
 from sage.client import AggregatorClient
+from sage.logging_config import configure_logging
 from sage.sender import delete_all_from_solr, send_to_solr
 from sage.state import get_checksum, save_checksum
 from sage.transfomer import transform_raw_dataset
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-)
-
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def calculate_checksum(datasets):
@@ -197,4 +193,5 @@ def main():
 
 
 if __name__ == "__main__":
+    configure_logging()
     main()

--- a/sage/pipeline.py
+++ b/sage/pipeline.py
@@ -16,9 +16,24 @@ def calculate_checksum(datasets):
     Calculate a deterministic checksum for the dataset snapshot.
 
     Dataset order does not affect the checksum.
+
+    The dynamically generated ODRL policy ID is excluded because
+    the Aggregator may generate a different value for the same
+    dataset between requests.
     """
-    normalized = sorted(
-        datasets,
+    normalized = []
+
+    for dataset in datasets:
+        dataset_copy = json.loads(json.dumps(dataset))
+
+        policy = dataset_copy.get("odrl:hasPolicy")
+
+        if isinstance(policy, dict):
+            policy.pop("@id", None)
+
+        normalized.append(dataset_copy)
+
+    normalized.sort(
         key=lambda dataset: dataset.get("@id", ""),
     )
 
@@ -31,7 +46,10 @@ def calculate_checksum(datasets):
 
     checksum = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
-    logger.debug("Calculated dataset checksum: %s", checksum)
+    logger.debug(
+        "Calculated dataset checksum: %s",
+        checksum,
+    )
 
     return checksum
 
@@ -53,10 +71,16 @@ def flatten_datasets(catalogs):
         )
         return datasets
 
-    logger.debug("Processing %d catalog objects", len(catalogs))
+    logger.debug(
+        "Processing %d catalog objects",
+        len(catalogs),
+    )
 
     for catalog in catalogs:
-        raw_datasets = catalog.get("dcat:dataset", [])
+        raw_datasets = catalog.get(
+            "dcat:dataset",
+            [],
+        )
 
         if isinstance(raw_datasets, dict):
             logger.debug("Found a single dataset object in catalog")
@@ -109,7 +133,10 @@ def main():
     # 2. Flatten catalogs into datasets
     raw_datasets = flatten_datasets(data)
 
-    logger.info("Total raw datasets: %d", len(raw_datasets))
+    logger.info(
+        "Total raw datasets: %d",
+        len(raw_datasets),
+    )
 
     if not raw_datasets:
         logger.warning("No datasets found in Aggregator response")
@@ -119,8 +146,14 @@ def main():
     current_checksum = calculate_checksum(raw_datasets)
     previous_checksum = get_checksum()
 
-    logger.debug("Previous checksum: %s", previous_checksum)
-    logger.debug("Current checksum: %s", current_checksum)
+    logger.debug(
+        "Previous checksum: %s",
+        previous_checksum,
+    )
+    logger.debug(
+        "Current checksum: %s",
+        current_checksum,
+    )
 
     # 4. Skip Solr update if nothing changed
     if current_checksum == previous_checksum:

--- a/sage/scheduler.py
+++ b/sage/scheduler.py
@@ -1,0 +1,26 @@
+"""Runs the SAGE pipeline on a cron schedule (every 10 minutes)."""
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from sage.pipeline import main as run_pipeline
+
+
+def run_pipeline_safely():
+    try:
+        run_pipeline()
+    except Exception as exc:
+        print(f"[ERROR] Pipeline run failed: {exc}")
+
+
+def main():
+    scheduler = BlockingScheduler(timezone="UTC")
+    scheduler.add_job(run_pipeline_safely, CronTrigger(minute="*/10"))
+
+    print("Starting SAGE scheduler (every 10 minutes)...")
+    run_pipeline_safely()  # run once immediately on startup
+    scheduler.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/sage/scheduler.py
+++ b/sage/scheduler.py
@@ -1,24 +1,51 @@
-"""Runs the SAGE pipeline on a cron schedule (every 10 minutes)."""
+"""Runs the SAGE pipeline on a configurable schedule."""
+
+from logging import getLogger
 
 from apscheduler.schedulers.blocking import BlockingScheduler
-from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
 
+from sage.logging_config import configure_logging
 from sage.pipeline import main as run_pipeline
+from sage.settings import settings
+
+logger = getLogger(__name__)
 
 
-def run_pipeline_safely():
+def run_pipeline_safely() -> None:
+    """Run the SAGE pipeline and prevent scheduler shutdown on failure."""
+    logger.info("Starting scheduled SAGE pipeline run")
+
     try:
         run_pipeline()
-    except Exception as exc:
-        print(f"[ERROR] Pipeline run failed: {exc}")
+    except Exception:
+        logger.exception("SAGE pipeline run failed")
 
 
-def main():
+def main() -> None:
+    configure_logging()
+
+    interval_minutes = settings.scheduler_interval_minutes
+
+    logger.info(
+        "Starting SAGE scheduler with interval of %d minutes",
+        interval_minutes,
+    )
+
     scheduler = BlockingScheduler(timezone="UTC")
-    scheduler.add_job(run_pipeline_safely, CronTrigger(minute="*/10"))
 
-    print("Starting SAGE scheduler (every 10 minutes)...")
-    run_pipeline_safely()  # run once immediately on startup
+    scheduler.add_job(
+        run_pipeline_safely,
+        trigger=IntervalTrigger(minutes=interval_minutes),
+        id="sage_pipeline",
+        replace_existing=True,
+    )
+
+    logger.info(
+        "SAGE scheduler started. First pipeline run will occur " "after %d minutes.",
+        interval_minutes,
+    )
+
     scheduler.start()
 
 

--- a/sage/settings.py
+++ b/sage/settings.py
@@ -25,5 +25,11 @@ class Settings(BaseSettings):
     # Network
     request_timeout: int = Field(30, alias="REQUEST_TIMEOUT")
 
+    # Scheduler
+    scheduler_interval_minutes: int = Field(
+        10,
+        alias="SCHEDULER_INTERVAL_MINUTES",
+    )
+
 
 settings = Settings()

--- a/sage/tests/conftest.py
+++ b/sage/tests/conftest.py
@@ -1,0 +1,18 @@
+import os
+
+os.environ.setdefault(
+    "AGGREGATOR_URL",
+    "https://aggregator.test",
+)
+os.environ.setdefault(
+    "AGGREGATOR_API_KEY",
+    "test-api-key",
+)
+os.environ.setdefault(
+    "SOLR_URL",
+    "https://solr.test",
+)
+os.environ.setdefault(
+    "SOLR_COLS_NAME",
+    "test-collection",
+)

--- a/sage/tests/test_pipeline.py
+++ b/sage/tests/test_pipeline.py
@@ -464,3 +464,47 @@ def test_main_performs_operations_in_correct_order(
         "send",
         "save_checksum",
     ]
+
+
+def test_calculate_checksum_ignores_dynamic_policy_id():
+    dataset = {
+        "@id": "dataset-1",
+        "name": "Test dataset",
+        "odrl:hasPolicy": {
+            "@id": "policy-id-1",
+            "@type": "odrl:Offer",
+            "odrl:permission": [],
+            "odrl:prohibition": [],
+            "odrl:obligation": [],
+        },
+    }
+
+    dataset_with_different_policy_id = {
+        "@id": "dataset-1",
+        "name": "Test dataset",
+        "odrl:hasPolicy": {
+            "@id": "policy-id-2",
+            "@type": "odrl:Offer",
+            "odrl:permission": [],
+            "odrl:prohibition": [],
+            "odrl:obligation": [],
+        },
+    }
+
+    assert calculate_checksum([dataset]) == calculate_checksum(
+        [dataset_with_different_policy_id]
+    )
+
+
+def test_calculate_checksum_does_not_modify_dataset():
+    dataset = {
+        "@id": "dataset-1",
+        "odrl:hasPolicy": {
+            "@id": "policy-id-1",
+            "@type": "odrl:Offer",
+        },
+    }
+
+    calculate_checksum([dataset])
+
+    assert dataset["odrl:hasPolicy"]["@id"] == "policy-id-1"


### PR DESCRIPTION
## Summary
- Run `sage.pipeline` every 10 minutes via APScheduler (`sage/scheduler.py`) instead of an external cron/shell loop, for the beta transformer deployment.
- Add `apscheduler` to `Pipfile` (needs `pipenv lock` before deploy).
- Document `python -m sage.scheduler` usage in `sage/README.md`.